### PR TITLE
feat: admin shelter show page average pet age feature with test

### DIFF
--- a/app/controllers/admin/shelters_controller.rb
+++ b/app/controllers/admin/shelters_controller.rb
@@ -6,6 +6,6 @@ class Admin::SheltersController < ApplicationController
   end
 
   def show
-    @shelter = Shelter.find_by_sql("SELECT name, address, city, zip FROM shelters WHERE id = #{params[:shelter_id]}")[0]
+    @shelter = Shelter.find_by_sql("SELECT id, name, address, city, zip FROM shelters WHERE id = #{params[:shelter_id]}")[0]
   end 
 end

--- a/app/models/shelter.rb
+++ b/app/models/shelter.rb
@@ -33,6 +33,10 @@ class Shelter < ApplicationRecord
     adoptable_pets.where('age >= ?', age_filter)
   end
 
+  def average_pet_age 
+    pets.average(:age)
+  end 
+
   def self.reverse_order
     find_by_sql("SELECT * FROM shelters ORDER BY shelters.name DESC")
   end

--- a/app/views/admin/shelters/show.html.erb
+++ b/app/views/admin/shelters/show.html.erb
@@ -2,3 +2,6 @@
 <p> Address: <%= @shelter.address%></p>
 <p> City / State: <%= @shelter.city%></p>
 <p> Zip Code: <%= @shelter.zip%></p>
+<h4><%= @shelter.name %> Statistics:</h4>
+<p>Average pet age: <%= @shelter.average_pet_age%>
+g

--- a/spec/features/admin/shelters/show_spec.rb
+++ b/spec/features/admin/shelters/show_spec.rb
@@ -12,4 +12,17 @@ RSpec.describe 'admin shelter show page' do
         expect(page).to have_content(mystery.city)
         expect(page).to have_content(mystery.zip)
     end 
+
+     it 'there is a section for stats where you see average age of all adoptable pets for that shelter' do 
+        mystery = Shelter.create!(name: 'Mystery Building', address: "323 Main St", city: 'Irvine, CA', zip: 76543, foster_program: false, rank: 9)
+        lucille = Pet.create(adoptable: true, age: 1, breed: 'sphynx', name: 'Lucille Bald', shelter_id: mystery.id)
+        lobster = Pet.create(adoptable: true, age: 3, breed: 'doberman', name: 'Lobster', shelter_id: mystery.id)
+        beethoven = Pet.create(adoptable: false, age: 2, breed: 'saint bernard', name: 'Beethoven', shelter_id: mystery.id) 
+        barey = Pet.create(adoptable: true, age: 7, breed: 'sphynx', name: 'Bare-y Manilow', shelter_id: mystery.id)
+       
+        visit "/admin/shelters/#{mystery.id}"        
+
+        expect(page).to have_content("#{mystery.name} Statistics")
+        expect(page).to have_content("Average pet age: 3.25")
+    end 
 end 


### PR DESCRIPTION
- admin shelter show page now has a statistics section
- average pet age for all pets associated with that shelter is shown
- test confirms functionality 
- 100% coverage within all models and features